### PR TITLE
docs: Fix readme about application server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ asdf で Node.js をインストールする
 
     $ yarn start
 
-ブラウザで `http://localhost:3000` にアクセス
+ブラウザで `http://localhost:5173` にアクセス
 
 ローカルでの PostgreSQL 停止(データは削除されない)
 


### PR DESCRIPTION
<img width="1917" alt="image" src="https://github.com/user-attachments/assets/cdb15dbf-3fa7-4f86-a04b-f8aaa4e3d9d1">

[vite - server port](https://vite.dev/config/server-options#server-port)