### PR TITLE
feat: 移動経路を青い線で表示する

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -88,6 +88,18 @@ L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
     '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
 }).addTo(map);
 
+let trackingPath = L.polyline([], { color: 'blue' }).addTo(map);
+
+function updatePosition() {
+  navigator.geolocation.getCurrentPosition((position) => {
+    const latlng = [position.coords.latitude, position.coords.longitude];
+    trackingPath.addLatLng(latlng);
+    map.panTo(latlng);
+  });
+}
+
+setInterval(updatePosition, 5000);
+
 // フォーム送信時の処理
 function onFormSubmit(e) {
   e.preventDefault();

--- a/src/main.js
+++ b/src/main.js
@@ -88,7 +88,7 @@ L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
     '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
 }).addTo(map);
 
-let trackingPath = L.polyline([], { color: 'blue' }).addTo(map);
+let trackingPath = L.polyline([], { color: "blue" }).addTo(map);
 
 function updatePosition() {
   navigator.geolocation.getCurrentPosition((position) => {


### PR DESCRIPTION
- 追加する機能の概要

  - 1分間隔で現在位置を取得する
  - 前回の位置と現在の位置の間に線を引く
  - 地図の起動中上記を繰り返す

- 追加する理由

  - 散歩した経路が分かるようにする